### PR TITLE
Update QuEST_example_in_python.py

### DIFF
--- a/Examples/QuEST_example_in_python.py
+++ b/Examples/QuEST_example_in_python.py
@@ -54,7 +54,7 @@ def run_example_interactive():
     ops.controlledCompactUnitary()(qureg=qureg, control=0, qubit=1, alpha=a, beta=b)
 
     ops.multiControlledUnitary()(qureg=qureg, controls=[
-        0, 1], number_controls=2, qubit=2, matrix=u)
+        0, 1], qubit=2, matrix=u)
 
     # cheated results
 


### PR DESCRIPTION
`ops.multiControlledUnitary()` determines number of controls within the definition. This could also be done for all other multi controlled gates. But this is simply consistent and will run "out of the box".